### PR TITLE
78600 - Terraform fix for Vnet integration 

### DIFF
--- a/Deployment/Modules/Webapp/main.tf
+++ b/Deployment/Modules/Webapp/main.tf
@@ -30,6 +30,10 @@ resource "azurerm_windows_web_app" "webapp_service" {
     type = "SystemAssigned"
     }
 
+  lifecycle {
+    ignore_changes = [ virtual_network_subnet_id ]
+   }
+
   https_only = true
   }
 

--- a/Deployment/Modules/Webapp/outputs.tf
+++ b/Deployment/Modules/Webapp/outputs.tf
@@ -15,5 +15,5 @@ output "webapp_name" {
 }
 
 output "mock_web_app_object_id" {
-  value = azurerm_windows_web_app.mock_webapp_service.0.identity.0.principal_id
+  value = var.env_name == "dev" ? azurerm_windows_web_app.mock_webapp_service.0.identity.0.principal_id : null
 }

--- a/Deployment/main.tf
+++ b/Deployment/main.tf
@@ -1,85 +1,91 @@
 data "azurerm_subnet" "main_subnet" {
-  name                 = var.spoke_subnet_name
-  virtual_network_name = var.spoke_vnet_name
-  resource_group_name  = var.spoke_rg
-}
-
-module "app_insights" {
-  source              = "./Modules/AppInsights"
-  name                = "${local.service_name}-${local.env_name}-insights"
-  resource_group_name = azurerm_resource_group.rg.name
-  location            = azurerm_resource_group.rg.location
-  tags                = local.tags
-}
-
-module "eventhub" {
-  source              = "./Modules/EventHub"
-  name                = "${local.service_name}-${local.env_name}-events"
-  resource_group_name = azurerm_resource_group.rg.name
-  location            = azurerm_resource_group.rg.location
-  tags                = local.tags
-  env_name            = local.env_name
-}
-
-module "webapp_service" {
-  source                    = "./Modules/Webapp"
-  name                      = local.web_app_name
-  mock_webapp_name          = local.mock_web_app_name
-  service_name              = local.service_name                 
-  resource_group_name       = azurerm_resource_group.rg.name
-  env_name                  = local.env_name
-  location                  = azurerm_resource_group.rg.location
-  sku_name                  = var.sku_name[local.env_name]
-  subnet_id                 = data.azurerm_subnet.main_subnet.id
-  app_settings = {
-    "KeyVaultSettings:ServiceUri"                              = "https://${local.key_vault_name}.vault.azure.net/"
-    "EventHubLoggingConfiguration:Environment"                 = local.env_name
-    "EventHubLoggingConfiguration:MinimumLoggingLevel"         = "Warning"
-    "EventHubLoggingConfiguration:UkhoMinimumLoggingLevel"     = "Information"
-    "APPINSIGHTS_INSTRUMENTATIONKEY"                           = module.app_insights.instrumentation_key
-    "ASPNETCORE_ENVIRONMENT"                                   = local.env_name
-    "WEBSITE_RUN_FROM_PACKAGE"                                 = "1"
-    "WEBSITE_ENABLE_SYNC_UPDATE_SITE"                          = "true"
+    name                 = var.spoke_subnet_name
+    virtual_network_name = var.spoke_vnet_name
+    resource_group_name  = var.spoke_rg
   }
-   mock_app_settings = {
-    "KeyVaultSettings:ServiceUri"                              = "https://${local.key_vault_name}.vault.azure.net/"
-    "ASPNETCORE_ENVIRONMENT"                                   = local.env_name
-    "WEBSITE_RUN_FROM_PACKAGE"                                 = "1"
-    "WEBSITE_ENABLE_SYNC_UPDATE_SITE"                          = "true"
-    }
-  tags                                                         = local.tags
-}
-
-module "key_vault" {
-  source              = "./Modules/KeyVault"
-  name                = local.key_vault_name
-  resource_group_name = azurerm_resource_group.rg.name
-  env_name            = local.env_name
-  tenant_id           = module.webapp_service.web_app_tenant_id
-  location            = azurerm_resource_group.rg.location
-
-  read_access_objects = {
-     "webapp_service"       = module.webapp_service.web_app_object_id
-     "mock_service"         = module.webapp_service.mock_web_app_object_id
-  }
-  secrets = {
-      "EventHubLoggingConfiguration--ConnectionString"            = module.eventhub.log_primary_connection_string
-      "EventHubLoggingConfiguration--EntityPath"                  = module.eventhub.entity_path
-      "ApplicationInsights--ConnectionString"                     = module.app_insights.connection_string
-      "AzureStorageConfiguration--ConnectionString"                = module.storage.storage_connection_string
-      
- }
-  tags                                                            = local.tags
-}
-
-module "storage" {
-  source                                = "./Modules/Storage"
-  name                                  = local.storage_name
-  resource_group_name                   = azurerm_resource_group.rg.name
-  location                              = azurerm_resource_group.rg.location
-  tags                                  = local.tags
-  table_name                            = local.table_name
-  container_name                        = local.container_name
-  webapp_principal_id                   = module.webapp_service.web_app_object_id
   
- }
+  module "app_insights" {
+    source              = "./Modules/AppInsights"
+    name                = "${local.service_name}-${local.env_name}-insights"
+    resource_group_name = azurerm_resource_group.rg.name
+    location            = azurerm_resource_group.rg.location
+    tags                = local.tags
+  }
+  
+  module "eventhub" {
+    source              = "./Modules/EventHub"
+    name                = "${local.service_name}-${local.env_name}-events"
+    resource_group_name = azurerm_resource_group.rg.name
+    location            = azurerm_resource_group.rg.location
+    tags                = local.tags
+    env_name            = local.env_name
+  }
+  
+  module "webapp_service" {
+    source                    = "./Modules/Webapp"
+    name                      = local.web_app_name
+    mock_webapp_name          = local.mock_web_app_name
+    service_name              = local.service_name                 
+    resource_group_name       = azurerm_resource_group.rg.name
+    env_name                  = local.env_name
+    location                  = azurerm_resource_group.rg.location
+    sku_name                  = var.sku_name[local.env_name]
+    subnet_id                 = data.azurerm_subnet.main_subnet.id
+    app_settings = {
+      "KeyVaultSettings:ServiceUri"                              = "https://${local.key_vault_name}.vault.azure.net/"
+      "EventHubLoggingConfiguration:Environment"                 = local.env_name
+      "EventHubLoggingConfiguration:MinimumLoggingLevel"         = "Warning"
+      "EventHubLoggingConfiguration:UkhoMinimumLoggingLevel"     = "Information"
+      "APPINSIGHTS_INSTRUMENTATIONKEY"                           = module.app_insights.instrumentation_key
+      "ASPNETCORE_ENVIRONMENT"                                   = local.env_name
+      "WEBSITE_RUN_FROM_PACKAGE"                                 = "1"
+      "WEBSITE_ENABLE_SYNC_UPDATE_SITE"                          = "true"
+    }
+     mock_app_settings = {
+      "KeyVaultSettings:ServiceUri"                              = "https://${local.key_vault_name}.vault.azure.net/"
+      "ASPNETCORE_ENVIRONMENT"                                   = local.env_name
+      "WEBSITE_RUN_FROM_PACKAGE"                                 = "1"
+      "WEBSITE_ENABLE_SYNC_UPDATE_SITE"                          = "true"
+      }
+    tags                                                         = local.tags
+  }
+  
+  locals {
+    kv_read_access_list = {
+   "webapp_service"  = module.webapp_service.web_app_object_id
+    }
+  
+    kv_read_access_list_with_mock   = merge(local.kv_read_access_list, {
+   "mock_service"      = local.env_name == "dev" ? module.webapp_service.mock_web_app_object_id : ""
+    })
+   }
+  
+  module "key_vault" {
+    source              = "./Modules/KeyVault"
+    name                = local.key_vault_name
+    resource_group_name = azurerm_resource_group.rg.name
+    env_name            = local.env_name
+    tenant_id           = module.webapp_service.web_app_tenant_id
+    location            = azurerm_resource_group.rg.location
+    read_access_objects = local.env_name == "dev" ? local.kv_read_access_list_with_mock : local.kv_read_access_list
+    secrets = {
+        "EventHubLoggingConfiguration--ConnectionString"            = module.eventhub.log_primary_connection_string
+        "EventHubLoggingConfiguration--EntityPath"                  = module.eventhub.entity_path
+        "ApplicationInsights--ConnectionString"                     = module.app_insights.connection_string
+        "AzureStorageConfiguration--ConnectionString"               = module.storage.storage_connection_string
+        
+   }
+    tags                                                            = local.tags
+  }
+  
+  module "storage" {
+    source                                = "./Modules/Storage"
+    name                                  = local.storage_name
+    resource_group_name                   = azurerm_resource_group.rg.name
+    location                              = azurerm_resource_group.rg.location
+    tags                                  = local.tags
+    table_name                            = local.table_name
+    container_name                        = local.container_name
+    webapp_principal_id                   = module.webapp_service.web_app_object_id
+    
+   }

--- a/Deployment/outputs.tf
+++ b/Deployment/outputs.tf
@@ -3,5 +3,5 @@ output "webapp_name" {
 }
 
 output "mock_webapp_name" {
-   value = local.mock_web_app_name
+   value = local.env_name == "dev" ? local.mock_web_app_name : null
 }


### PR DESCRIPTION
PR Contains changes for 

**Fix applied on Vnet Integration change** 
Lifecycle block with ignore changes has been added as per the suggestion on terraform.io documentation, Since exisiting azurerm version destroys changes in next run for Vnet Integration. 
https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/windows_web_app#virtual_network_subnet_id 

Empty mock service object id Keyvault Access policies resource block in QA environment
This was identified in after QA deployment on deployment of main branch. Change was left to add in exisiting PR branch for SAP Mock API end point changes https://github.com/UKHO/erp-facade/pull/11 . Change has been included here along with terraform fix.


 