### PR TITLE
Changed OPTION route for webhook endpoint

### DIFF
--- a/src/UKHO.ERPFacade.API/Controllers/WebhookController.cs
+++ b/src/UKHO.ERPFacade.API/Controllers/WebhookController.cs
@@ -47,7 +47,7 @@ namespace UKHO.ERPFacade.API.Controllers
         }
 
         [HttpOptions]
-        [Route("/webhook/newenccontentpublishedeventoptions")]
+        [Route("/webhook/newenccontentpublishedeventreceived")]
         [Authorize(Policy = "WebhookCaller")]
         public IActionResult NewEncContentPublishedEventOptions()
         {

--- a/tests/UKHO.ERPFacade.API.FunctionalTests/Helpers/WebhookEndpoint.cs
+++ b/tests/UKHO.ERPFacade.API.FunctionalTests/Helpers/WebhookEndpoint.cs
@@ -27,7 +27,7 @@ namespace UKHO.ERPFacade.API.FunctionalTests.Helpers
 
         public async Task<RestResponse> OptionWebhookResponseAsync(string token)
         {
-            var request = new RestRequest("/webhook/newenccontentpublishedeventoptions");
+            var request = new RestRequest("/webhook/newenccontentpublishedeventreceived");
             request.AddHeader("Authorization", "Bearer " + token);
             var response = await client.OptionsAsync(request);
             return response;


### PR DESCRIPTION
Changed the HTTP OPTION endpoint route to be the same as the POST request for the webhook endpoint. This is required by EES.