### PR TITLE
145255 disable record of sale endpoints.

### DIFF
--- a/Deployment/main.tf
+++ b/Deployment/main.tf
@@ -41,6 +41,7 @@ module "webapp_service" {
     "WEBSITE_RUN_FROM_PACKAGE"                                 = "1"
     "WEBSITE_ENABLE_SYNC_UPDATE_SITE"                          = "true"
     "WEBSITE_ADD_SITENAME_BINDINGS_IN_APPHOST_CONFIG"          = "1"
+    "WEBJOBs_STOPPED"                                           = "1"
   }
   mock_app_settings = {
     "KeyVaultSettings:ServiceUri"                              = "https://${local.key_vault_name}.vault.azure.net/"

--- a/Deployment/main.tf
+++ b/Deployment/main.tf
@@ -41,7 +41,6 @@ module "webapp_service" {
     "WEBSITE_RUN_FROM_PACKAGE"                                 = "1"
     "WEBSITE_ENABLE_SYNC_UPDATE_SITE"                          = "true"
     "WEBSITE_ADD_SITENAME_BINDINGS_IN_APPHOST_CONFIG"          = "1"
-    "WEBJOBS_STOPPED"                                          = "1"
   }
   mock_app_settings = {
     "KeyVaultSettings:ServiceUri"                              = "https://${local.key_vault_name}.vault.azure.net/"

--- a/Deployment/main.tf
+++ b/Deployment/main.tf
@@ -41,6 +41,7 @@ module "webapp_service" {
     "WEBSITE_RUN_FROM_PACKAGE"                                 = "1"
     "WEBSITE_ENABLE_SYNC_UPDATE_SITE"                          = "true"
     "WEBSITE_ADD_SITENAME_BINDINGS_IN_APPHOST_CONFIG"          = "1"
+    "WEBJOBS_STOPPED"                                          = "1"
   }
   mock_app_settings = {
     "KeyVaultSettings:ServiceUri"                              = "https://${local.key_vault_name}.vault.azure.net/"

--- a/Deployment/main.tf
+++ b/Deployment/main.tf
@@ -41,7 +41,7 @@ module "webapp_service" {
     "WEBSITE_RUN_FROM_PACKAGE"                                 = "1"
     "WEBSITE_ENABLE_SYNC_UPDATE_SITE"                          = "true"
     "WEBSITE_ADD_SITENAME_BINDINGS_IN_APPHOST_CONFIG"          = "1"
-    "WEBJOBs_STOPPED"                                           = "1"
+    "WEBJOBS_STOPPED"                                          = "1"
   }
   mock_app_settings = {
     "KeyVaultSettings:ServiceUri"                              = "https://${local.key_vault_name}.vault.azure.net/"

--- a/Deployment/templates/continuous-deployment-app.yml
+++ b/Deployment/templates/continuous-deployment-app.yml
@@ -37,6 +37,13 @@ steps:
       fileType: 'json'
       targetFiles: '**/appsettings.json'
 
+  - task: PowerShell@2
+    displayName: "Stop Event Aggregator Webjob "
+    inputs:
+      targetType: 'inline'
+      script: |
+          Get-AzWebAppContinuousWebJob -ResourceGroupName $(ResourceGroup) -AppName $(WEB_APP_NAME) -Name EventAggregationWebJob | Stop-AzWebAppContinuousWebJob
+          
   - task: AzureWebApp@1
     displayName: "Azure App Deploy: Staging slot"
     inputs:

--- a/Deployment/templates/continuous-deployment-app.yml
+++ b/Deployment/templates/continuous-deployment-app.yml
@@ -36,14 +36,6 @@ steps:
       folderPath: '$(Pipeline.Workspace)/UKHOERPFacadeAPI/*.zip'
       fileType: 'json'
       targetFiles: '**/appsettings.json'
-
-  - task: AzureCLI@2
-    displayName: "Stop Event Aggregator Webjob"
-    inputs:
-      azureSubscription: "ERP-Facade-Dev-A.011.05.12"
-      scriptType: 'pscore'
-      scriptLocation: 'inlineScript'
-      inlineScript: 'Get-AzWebAppContinuousWebJob -ResourceGroupName $(ResourceGroup) -AppName $(WEB_APP_NAME) -Name EventAggregationWebJob | Stop-AzWebAppContinuousWebJob'
            
   - task: AzureWebApp@1
     displayName: "Azure App Deploy: Staging slot"

--- a/Deployment/templates/continuous-deployment-app.yml
+++ b/Deployment/templates/continuous-deployment-app.yml
@@ -37,13 +37,14 @@ steps:
       fileType: 'json'
       targetFiles: '**/appsettings.json'
 
-  - task: PowerShell@2
-    displayName: "Stop Event Aggregator Webjob "
+  - task: AzureCLI@2
+    displayName: "Stop Event Aggregator Webjob"
     inputs:
-      targetType: 'inline'
-      script: |
-          Get-AzWebAppContinuousWebJob -ResourceGroupName $(ResourceGroup) -AppName $(WEB_APP_NAME) -Name EventAggregationWebJob | Stop-AzWebAppContinuousWebJob
-          
+      azureSubscription: "ERP-Facade-Dev-A.011.05.12"
+      scriptType: 'pscore'
+      scriptLocation: 'inlineScript'
+      inlineScript: 'Get-AzWebAppContinuousWebJob -ResourceGroupName $(ResourceGroup) -AppName $(WEB_APP_NAME) -Name EventAggregationWebJob | Stop-AzWebAppContinuousWebJob'
+           
   - task: AzureWebApp@1
     displayName: "Azure App Deploy: Staging slot"
     inputs:

--- a/NVDSuppressions.xml
+++ b/NVDSuppressions.xml
@@ -458,5 +458,15 @@
    ]]></notes>
    <packageUrl regex="true">^pkg:generic/Elastic\.Apm@.*$</packageUrl>
    <cve>CVE-2019-7617</cve>
-  </suppress>  
+  </suppress>
+  <suppress>
+    <notes>
+      <![CDATA[
+   file name: GetDocument.Insider.dll
+   Vunerability is related to a Dotnet tool function that is not used in the production code
+   ]]>
+    </notes>
+    <cve>CVE-2024-21386</cve>
+    <cve>CVE-2024-21404</cve>
+  </suppress>
 </suppressions>

--- a/src/UKHO.ERPFacade.API/Controllers/WebhookController.cs
+++ b/src/UKHO.ERPFacade.API/Controllers/WebhookController.cs
@@ -138,6 +138,7 @@ namespace UKHO.ERPFacade.API.Controllers
         [HttpPost]
         [Route("/webhook/recordofsalepublishedeventreceived")]
         [Authorize(Policy = "RecordOfSaleWebhookCaller")]
+        [NonAction]
         public virtual async Task<IActionResult> RecordOfSalePublishedEventReceived([FromBody] JObject recordOfSaleEventJson)
         {
             _logger.LogInformation(EventIds.RecordOfSalePublishedEventReceived.ToEventId(), "ERP Facade webhook has received record of sale event from EES.");
@@ -185,6 +186,7 @@ namespace UKHO.ERPFacade.API.Controllers
         [HttpPost]
         [Route("/webhook/licenceupdatedpublishedeventreceived")]
         [Authorize(Policy = "LicenceUpdatedWebhookCaller")]
+        [NonAction]
         public virtual async Task<IActionResult> LicenceUpdatedPublishedEventReceived([FromBody] JObject licenceUpdatedEventJson)
         {
             _logger.LogInformation(EventIds.LicenceUpdatedEventPublishedEventReceived.ToEventId(), "ERP Facade webhook has received new licence updated publish event from EES.");

--- a/tests/UKHO.ERPFacade.API.FunctionalTests/FunctionalTests/LicenceUpdatedWebhookScenario.cs
+++ b/tests/UKHO.ERPFacade.API.FunctionalTests/FunctionalTests/LicenceUpdatedWebhookScenario.cs
@@ -7,6 +7,7 @@ using UKHO.ERPFacade.API.FunctionalTests.Service;
 
 namespace UKHO.ERPFacade.API.FunctionalTests.FunctionalTests
 {
+    [Ignore("It was originally built for ADDS Increment 3")]
     [TestFixture]
     public class LicenceUpdatedWebhookScenario
     {

--- a/tests/UKHO.ERPFacade.API.FunctionalTests/FunctionalTests/LicenceUpdatedWebhookScenario.cs
+++ b/tests/UKHO.ERPFacade.API.FunctionalTests/FunctionalTests/LicenceUpdatedWebhookScenario.cs
@@ -7,7 +7,7 @@ using UKHO.ERPFacade.API.FunctionalTests.Service;
 
 namespace UKHO.ERPFacade.API.FunctionalTests.FunctionalTests
 {
-    [Ignore("It was originally built for ADDS Increment 3")]
+    
     [TestFixture]
     public class LicenceUpdatedWebhookScenario
     {
@@ -44,6 +44,7 @@ namespace UKHO.ERPFacade.API.FunctionalTests.FunctionalTests
             response.StatusCode.Should().Be(System.Net.HttpStatusCode.Forbidden);
         }
 
+        [Ignore("It was originally built for ADDS Increment 3")]
         [Test, Order(0)]
         [TestCase("LU01_ValidInput.json", TestName = "WhenValidLUEventInLicenceUpdatedPublishedEventReceivedPostReceivedWithValidToken_ThenWebhookReturns200OkResponse")]
         public async Task WhenValidLUEventInLicenceUpdatedPublishedEventReceivedPostReceivedWithValidToken_ThenWebhookReturns200OkResponse(string payloadFileName)
@@ -53,6 +54,7 @@ namespace UKHO.ERPFacade.API.FunctionalTests.FunctionalTests
             response.StatusCode.Should().Be(System.Net.HttpStatusCode.OK);
         }
 
+        [Ignore("It was originally built for ADDS Increment 3")]
         [Test, Order(1)]
         [TestCase("LU01_ValidInput.json", TestName = "WhenValidLUEventInLicenceUpdatedPublishedEventReceivedPostReceivedWithInvalidToken_ThenWebhookReturns401UnauthorizedResponse")]
         public async Task WhenValidLUEventInLicenceUpdatedPublishedEventReceivedPostReceivedWithInvalidToken_ThenWebhookReturns401UnauthorizedResponse(string payloadFileName)
@@ -62,6 +64,7 @@ namespace UKHO.ERPFacade.API.FunctionalTests.FunctionalTests
             response.StatusCode.Should().Be(System.Net.HttpStatusCode.Unauthorized);
         }
 
+        [Ignore("It was originally built for ADDS Increment 3")]
         [Test, Order(3)]
         [TestCase("LU01_ValidInput.json", TestName = "WhenValidLUEventInLicenceUpdatedPublishedEventReceivedPostReceivedWithInvalidToken_ThenWebhookReturns403ForbiddenResponse")]
         public async Task WhenValidLUEventInLicenceUpdatedPublishedEventReceivedPostReceivedWithInvalidToken_ThenWebhookReturns403ForbiddenResponse(string payloadFileName)
@@ -71,6 +74,7 @@ namespace UKHO.ERPFacade.API.FunctionalTests.FunctionalTests
             response.StatusCode.Should().Be(System.Net.HttpStatusCode.Forbidden);
         }
 
+        [Ignore("It was originally built for ADDS Increment 3")]
         [Test, Order(2)]
         [TestCase("LU04_InvalidLUJsonFile.json", TestName = "WhenInValidLUEventInLicenceUpdatedPublishedEventReceivedPostReceived_ThenWebhookReturns400BadRequestResponse")]
         public async Task WhenInValidLUEventInLicenceUpdatedPublishedEventReceivedPostReceived_ThenWebhookReturns400BadRequestResponse(string payloadFileName)
@@ -80,6 +84,7 @@ namespace UKHO.ERPFacade.API.FunctionalTests.FunctionalTests
             response.StatusCode.Should().Be(System.Net.HttpStatusCode.BadRequest);
         }
 
+        [Ignore("It was originally built for ADDS Increment 3")]
         [Test, Order(2)]
         [TestCase("LU02_UnSupportedPayloadType.xml", TestName = "WhenInvalidLUEventInLicenceUpdatedPublishedEventReceivedPostReceivedWithInvalidPayloadType_ThenWebhookReturns415UnsupportedMediaResponse")]
         public async Task WhenInvalidLUEventInLicenceUpdatedPublishedEventReceivedPostReceivedWithInvalidPayloadType_ThenWebhookReturns415UnsupportedMediaResponse(string payloadFileName)
@@ -89,6 +94,7 @@ namespace UKHO.ERPFacade.API.FunctionalTests.FunctionalTests
             response.StatusCode.Should().Be(System.Net.HttpStatusCode.UnsupportedMediaType);
         }
 
+        [Ignore("It was originally built for ADDS Increment 3")]
         [Test, Order(0)]
         [TestCase("LU01_ValidInput.json", TestName = "WhenValidLUEventInLicenceUpdatedPublishedEventReceivedPostReceivedWithValidPayload_ThenWebhookReturns200OkResponse")]
         public async Task WhenValidLUEventInLicenceUpdatedPublishedEventReceivedPostReceivedWithValidPayload_ThenWebhookReturns200OkResponse(string payloadJsonFileName)
@@ -100,6 +106,7 @@ namespace UKHO.ERPFacade.API.FunctionalTests.FunctionalTests
             response.StatusCode.Should().Be(System.Net.HttpStatusCode.OK);
         }
 
+        [Ignore("It was originally built for ADDS Increment 3")]
         [TestCase("LU03_InvalidLUJsonFile.json", TestName = "WhenValidLUEventInLicenceUpdatedPublishedEventReceivedPostReceivedWithInvalidPayload_ThenWebhookReturns500InternalServerErrorResponse")]
         public async Task WhenValidLUEventInLicenceUpdatedPublishedEventReceivedPostReceivedWithInvalidPayload_ThenWebhookReturns500InternalServerErrorResponse(string payloadFileName)
         {

--- a/tests/UKHO.ERPFacade.API.FunctionalTests/FunctionalTests/RoSWebhookScenarios.cs
+++ b/tests/UKHO.ERPFacade.API.FunctionalTests/FunctionalTests/RoSWebhookScenarios.cs
@@ -8,6 +8,7 @@ using UKHO.ERPFacade.API.FunctionalTests.Service;
 
 namespace UKHO.ERPFacade.API.FunctionalTests.FunctionalTests
 {
+    [Ignore("It was originally built for ADDS Increment 3")]
     [TestFixture]
     public class RoSWebhookScenarios
     {

--- a/tests/UKHO.ERPFacade.API.FunctionalTests/FunctionalTests/RoSWebhookScenarios.cs
+++ b/tests/UKHO.ERPFacade.API.FunctionalTests/FunctionalTests/RoSWebhookScenarios.cs
@@ -8,7 +8,7 @@ using UKHO.ERPFacade.API.FunctionalTests.Service;
 
 namespace UKHO.ERPFacade.API.FunctionalTests.FunctionalTests
 {
-    [Ignore("It was originally built for ADDS Increment 3")]
+    
     [TestFixture]
     public class RoSWebhookScenarios
     {
@@ -46,6 +46,7 @@ namespace UKHO.ERPFacade.API.FunctionalTests.FunctionalTests
             response.StatusCode.Should().Be(System.Net.HttpStatusCode.Forbidden);
         }
 
+        [Ignore("It was originally built for ADDS Increment 3")]
         [Test, Order(0)]
         [TestCase("RoS01_ValidRoSMainHolding.json", TestName = "WhenValidRoSEventInRecordOfSalePublishedEventPostReceivedWithValidToken_ThenWebhookReturns200OkResponse")]
         public async Task WhenValidRoSEventInRecordOfSalePublishedEventPostReceivedWithValidToken_ThenWebhookReturns200OkResponse(string payloadFileName)
@@ -55,6 +56,7 @@ namespace UKHO.ERPFacade.API.FunctionalTests.FunctionalTests
             response.StatusCode.Should().Be(System.Net.HttpStatusCode.OK);
         }
 
+        [Ignore("It was originally built for ADDS Increment 3")]
         [Test, Order(1)]
         [TestCase("RoS01_ValidRoSMainHolding.json", TestName = "WhenValidRoSEventInRecordOfSalePublishedEventPostReceivedWithInvalidToken_ThenWebhookReturns401UnauthorizedResponse")]
         public async Task WhenValidRoSEventInRecordOfSalePublishedEventPostReceivedWithInvalidToken_ThenWebhookReturns401UnauthorizedResponse(string payloadFileName)
@@ -64,6 +66,7 @@ namespace UKHO.ERPFacade.API.FunctionalTests.FunctionalTests
             response.StatusCode.Should().Be(System.Net.HttpStatusCode.Unauthorized);
         }
 
+        [Ignore("It was originally built for ADDS Increment 3")]
         [Test, Order(3)]
         [TestCase("RoS01_ValidRoSMainHolding.json", TestName = "WhenValidRoSEventInRecordOfSalePublishedEventPostReceivedWithInvalidToken_ThenWebhookReturns403ForbiddenResponse")]
         public async Task WhenValidRoSEventInRecordOfSalePublishedEventPostReceivedWithInvalidToken_ThenWebhookReturns403ForbiddenResponse(string payloadFileName)
@@ -73,6 +76,7 @@ namespace UKHO.ERPFacade.API.FunctionalTests.FunctionalTests
             response.StatusCode.Should().Be(System.Net.HttpStatusCode.Forbidden);
         }
 
+        [Ignore("It was originally built for ADDS Increment 3")]
         [Test, Order(2)]
         [TestCase("LTC03_InValidLTCwithNoCorrelationID.json", TestName = "WhenValidRoSMigrateNewLicencePublishedEventReceivedWithInvalidPayload_ThenWebhookReturns400BadRequestResponse")]
         [TestCase("LTC05_InValidLTCwithNoCorrelationID.json", TestName = "WhenValidRoSMigrateExistingLicencePublishedEventReceivedWithInvalidPayload_ThenWebhookReturns400BadRequestResponse")]
@@ -85,6 +89,7 @@ namespace UKHO.ERPFacade.API.FunctionalTests.FunctionalTests
             response.StatusCode.Should().Be(System.Net.HttpStatusCode.BadRequest);
         }
 
+        [Ignore("It was originally built for ADDS Increment 3")]
         [Test, Order(2)]
         [TestCase("RoS12_UnSupportedPayloadType.xml", TestName = "WhenInvalidRoSEventInRecordOfSalePublishedEventPostReceivedWithInvalidPayloadType_ThenWebhookReturns415UnsupportedMediaResponse")]
         public async Task WhenInvalidRoSEventInRecordOfSalePublishedEventPostReceivedWithInvalidPayloadType_ThenWebhookReturns415UnsupportedMediaResponse(string payloadFileName)
@@ -94,6 +99,7 @@ namespace UKHO.ERPFacade.API.FunctionalTests.FunctionalTests
             response.StatusCode.Should().Be(System.Net.HttpStatusCode.UnsupportedMediaType);
         }
 
+        [Ignore("It was originally built for ADDS Increment 3")]
         [TestCase("RoS01_ValidRoSMainHolding.json", TestName = "WhenValidRoSEventInRecordOfSalePublishedEventReceivedPostReceivedMaintainHoldingWithValidPayload_ThenWebhookReturns200OkResponse")]
         [TestCase("RoS02_ValidRoSMainHolding900UoS.json", TestName = "WhenValidRoSEventInRecordOfSalePublishedEventReceivedMaintainHoldingPostReceivedWithValidPayload900UoS_ThenWebhookReturns200OkResponse")]
         [TestCase("RoS03_ValidRoSMainHolding2000UoS.json", TestName = "WhenValidRoSEventInRecordOfSalePublishedEventReceivedMaintainHoldingPostReceivedWithValidPayload2000UoS_ThenWebhookReturns200OkResponse")]
@@ -110,6 +116,7 @@ namespace UKHO.ERPFacade.API.FunctionalTests.FunctionalTests
             response.StatusCode.Should().Be(System.Net.HttpStatusCode.OK);
         }
 
+        [Ignore("It was originally built for ADDS Increment 3")]
         [TestCase("LTC02_InvalidRoSMigrateNewLicence.json", TestName = "WhenValidRoSMigrateNewLicencePublishedEventReceivedWithInvalidPayload_ThenWebhookReturns500InternalServerError")]
         [TestCase("LTC06_InvalidRoSMigrateExistingLicence.json", TestName = "WhenValidRoSMigrateExistingLicencePublishedEventReceivedWithInvalidPayload_ThenWebhookReturns500InternalServerError")]
         [TestCase("LTC08_InvalidRoSConvertTrialToFullLicence.json", TestName = "WhenValidRoSConvertTrialToFullNewLicencePublishedEventReceivedWithInvalidPayload_ThenWebhookReturns500InternalServerError")]
@@ -122,7 +129,8 @@ namespace UKHO.ERPFacade.API.FunctionalTests.FunctionalTests
             RestResponse response = await RosWebhookEndpoint.PostWebhookResponseAsync(filePath, await _authToken.GetAzureADToken(false));
             response.StatusCode.Should().Be(System.Net.HttpStatusCode.InternalServerError);
         }
-       
+
+        [Ignore("It was originally built for ADDS Increment 3")]
         [TestCase("RoS13_ValidFirstPayloadForMerging.json", "RoS13_ValidLastPayloadForMerging.json", TestName = "WhenValidRoSEventsReceivedWithValidPayloadsForMerging_ThenWebhookReturns200OkResponseAndWebJobCreatesXMLPayload")]
         public async Task WhenValidRoSEventsReceivedWithValidPayloadsForMerging_ThenWebhookReturns200OkResponseAndWebJobCreatesXMLPayload(string firstEventPayloadJsonFileName, string lastEventPayloadJsonFileName)
         {
@@ -147,6 +155,7 @@ namespace UKHO.ERPFacade.API.FunctionalTests.FunctionalTests
             lastEventResponse.StatusCode.Should().Be(System.Net.HttpStatusCode.OK);
         }
 
+        [Ignore("It was originally built for ADDS Increment 3")]
         [TestCase("LTC01_RoSMigrateNewLicence.json", TestName = "WhenValidRoSMigrateNewLicencePublishedEventReceivedWithValidPayload_ThenWebhookReturns200OkResponse")]
         [TestCase("LTC04_RoSMigrateExistingLicence.json", TestName = "WhenValidRoSMigrateExistingLicencePublishedEventReceivedWithValidPayload_ThenWebhookReturns200OkResponse")]
         [TestCase("LTC07_RoSConvertTrialToFullLicence.json", TestName = "WhenValidRoSConvertTrialToFullLicencePublishedEventReceivedWithValidPayload_ThenWebhookReturns200OkResponse")]


### PR DESCRIPTION
ERP facade endpoint recordofsalepublishedeventreceived and licenceupdatedpublishedeventreceived disabled to restrict Fleet Manager order processing capabilities.

Also, related Functional Test Cases are marked as ignored. 