### PR TITLE
Remove FT running in IAT pipeline

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -204,7 +204,6 @@ stages:
         AppPool: $(DeploymentPoolPE)
         Container: ${{variables.Container}}
         DeployADDSMocks: true
-        RunFunctionalTests: true
         RunAddsTests: IAT
   
   - stage: PreProdDeploy

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -10,13 +10,6 @@ parameters:
     displayName: "Run Stryker test mutation"
     type: boolean
     default: true
-  - name: StrykerVersion
-    displayName: "Stryker version"
-    type: string
-    values:
-      - 'latest'
-      - '4.8.1'
-    default: 'latest'
   - name: SnykOnlyFailIfFixable
     displayName: "Snyk - fail only if an issue has an available fix"
     type: boolean
@@ -105,10 +98,7 @@ stages:
             inputs:
               command: custom
               custom: tool
-              ${{ if eq(parameters.StrykerVersion, 'latest') }}:
-                arguments: install dotnet-stryker --tool-path $(Agent.BuildDirectory)/tools --configfile $(Build.SourcesDirectory)/BuildNuget.config
-              ${{ else }}:
-                arguments: install dotnet-stryker --tool-path $(Agent.BuildDirectory)/tools --configfile $(Build.SourcesDirectory)/BuildNuget.config --version ${{ parameters.StrykerVersion }}
+              arguments: install dotnet-stryker --tool-path $(Agent.BuildDirectory)/tools --configfile $(Build.SourcesDirectory)/BuildNuget.config
 
           - task: DotNetCoreCLI@2
             displayName: ".Net Core - NuGet restore for non test projects only"


### PR DESCRIPTION
This pull request simplifies the Azure Pipelines configuration by removing the ability to select a specific Stryker version and making related adjustments. The changes focus on streamlining the pipeline parameters and tasks.

Pipeline configuration simplification:

* Removed the `StrykerVersion` parameter from the pipeline, so the pipeline will always use the latest version of Stryker instead of allowing a specific version to be selected.
* Updated the Stryker installation step to always install the latest version, removing conditional logic for different versions.

Other pipeline adjustments:

* Removed the `RunFunctionalTests` variable from the `stages` section, possibly indicating a change in test execution strategy.