### PR TITLE
Add Microsoft.OpenApi NuGet package reference

### DIFF
--- a/mock/UKHO.ADDS.Mocks.ERP/UKHO.ADDS.Mocks.ERP.csproj
+++ b/mock/UKHO.ADDS.Mocks.ERP/UKHO.ADDS.Mocks.ERP.csproj
@@ -12,6 +12,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.9" />
+    <PackageReference Include="Microsoft.OpenApi" Version="2.7.5" />
     <PackageReference Include="UKHO.ADDS.Mocks" Version="1.0.60515-rc.2" />
   </ItemGroup>
 


### PR DESCRIPTION
Added Microsoft.OpenApi version 2.7.5 to UKHO.ADDS.Mocks.ERP.csproj to support OpenAPI-related functionality. No other changes were made.