### PR TITLE
Fix webjob appinsights issue - Downgrade App Insights and use InMemoryChannel for telemetry to fix webjob 

### DIFF
--- a/src/UKHO.ERPFacade.API/UKHO.ERPFacade.API.csproj
+++ b/src/UKHO.ERPFacade.API/UKHO.ERPFacade.API.csproj
@@ -31,7 +31,7 @@
     <PackageReference Include="Azure.Extensions.AspNetCore.Configuration.Secrets" Version="1.5.1" />
     <PackageReference Include="Azure.Identity" Version="1.21.0" />
     <PackageReference Include="Elastic.Apm.NetCoreAll" Version="1.34.5" />
-    <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="3.1.2" />
+    <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.23.0" />
 
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.9" />
     <PackageReference Include="Microsoft.AspNetCore.HeaderPropagation" Version="10.0.9" />

--- a/src/UKHO.ERPFacade.CleanUp.WebJob/Program.cs
+++ b/src/UKHO.ERPFacade.CleanUp.WebJob/Program.cs
@@ -138,6 +138,7 @@ namespace UKHO.ERPFacade.Monitoring.WebJob
                     config.TelemetryChannel = telemetryChannel;
                 }
             );
+
             if (configuration != null)
             {
                 serviceCollection.Configure<CleanupWebJobConfiguration>(configuration.GetSection("CleanupWebJobConfiguration"));

--- a/src/UKHO.ERPFacade.CleanUp.WebJob/Program.cs
+++ b/src/UKHO.ERPFacade.CleanUp.WebJob/Program.cs
@@ -21,7 +21,7 @@ namespace UKHO.ERPFacade.Monitoring.WebJob
     public static class Program
     {
         private static readonly string WebJobAssemblyVersion = Assembly.GetExecutingAssembly().GetCustomAttributes<AssemblyFileVersionAttribute>().Single().Version;
-
+        private static readonly InMemoryChannel telemetryChannel = new();
         public static async Task Main()
         {
             try
@@ -41,11 +41,12 @@ namespace UKHO.ERPFacade.Monitoring.WebJob
 
                 try
                 {
-                   await serviceProvider.GetService<CleanUpWebjob>().Start();
+                    await serviceProvider.GetService<CleanUpWebjob>().Start();
                 }
                 finally
                 {
                     // Ensure any buffered app insights logs are flushed into Azure (if configured)
+                    telemetryChannel.Flush();
                     await Task.Delay(delayTime);
                 }
             }
@@ -131,8 +132,12 @@ namespace UKHO.ERPFacade.Monitoring.WebJob
                 }
             });
 
-            // TelemetryConfiguration customization removed: telemetry channel types are provided by the Application Insights packages
-
+            serviceCollection.Configure<TelemetryConfiguration>(
+                (config) =>
+                {
+                    config.TelemetryChannel = telemetryChannel;
+                }
+            );
             if (configuration != null)
             {
                 serviceCollection.Configure<CleanupWebJobConfiguration>(configuration.GetSection("CleanupWebJobConfiguration"));

--- a/src/UKHO.ERPFacade.CleanUp.WebJob/UKHO.ERPFacade.CleanUp.WebJob.csproj
+++ b/src/UKHO.ERPFacade.CleanUp.WebJob/UKHO.ERPFacade.CleanUp.WebJob.csproj
@@ -31,7 +31,7 @@
     <PackageReference Include="Azure.Extensions.AspNetCore.Configuration.Secrets" Version="1.5.1" />
     <PackageReference Include="Azure.Identity" Version="1.21.0" />
     <PackageReference Include="Azure.Security.KeyVault.Secrets" Version="4.11.0" />
-    <PackageReference Include="Microsoft.ApplicationInsights.WorkerService" Version="3.1.2" />
+    <PackageReference Include="Microsoft.ApplicationInsights.WorkerService" Version="2.23.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.9" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.9" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.9" />

--- a/src/UKHO.ERPFacade.EventAggregation.WebJob/Program.cs
+++ b/src/UKHO.ERPFacade.EventAggregation.WebJob/Program.cs
@@ -29,6 +29,7 @@ namespace UKHO.ERPFacade.EventAggregation.WebJob
     {
         private static IConfiguration? ConfigurationBuilder;
         private static readonly string WebJobAssemblyVersion = Assembly.GetExecutingAssembly().GetCustomAttributes<AssemblyFileVersionAttribute>().Single().Version;
+        private static readonly InMemoryChannel telemetryChannel = new();
 
         public static void Main(string[] args)
         {
@@ -105,7 +106,12 @@ namespace UKHO.ERPFacade.EventAggregation.WebJob
              .ConfigureServices((hostContext, services) =>
              {
                  services.AddApplicationInsightsTelemetryWorkerService();
-                 // TelemetryConfiguration customization removed: telemetry channel types are provided by the Application Insights packages
+                 services.Configure<TelemetryConfiguration>(
+                     (config) =>
+                     {
+                         config.TelemetryChannel = telemetryChannel;
+                     }
+                 );
 
                  var buildServiceProvider = services.BuildServiceProvider();
                  services.Configure<AzureStorageConfiguration>(ConfigurationBuilder.GetSection("AzureStorageConfiguration"));

--- a/src/UKHO.ERPFacade.EventAggregation.WebJob/UKHO.ERPFacade.EventAggregation.WebJob.csproj
+++ b/src/UKHO.ERPFacade.EventAggregation.WebJob/UKHO.ERPFacade.EventAggregation.WebJob.csproj
@@ -26,7 +26,7 @@
   <ItemGroup>
     <PackageReference Include="Azure.Extensions.AspNetCore.Configuration.Secrets" Version="1.5.1" />
     <PackageReference Include="Azure.Identity" Version="1.21.0" />
-    <PackageReference Include="Microsoft.ApplicationInsights.WorkerService" Version="3.1.2" />
+    <PackageReference Include="Microsoft.ApplicationInsights.WorkerService" Version="2.23.0" />
     <PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.47" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Storage" Version="5.3.7" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Host.Storage" Version="5.0.2" />


### PR DESCRIPTION
Downgraded Microsoft.ApplicationInsights packages to 2.23.0 across API and WebJob projects. Updated CleanUp and EventAggregation WebJobs to use InMemoryChannel for telemetry and explicitly configure TelemetryConfiguration. Ensured telemetry is flushed on shutdown and updated related comments.